### PR TITLE
fix: Update Ivandis / Blisterwood info on temple trekking

### DIFF
--- a/minigames/temple-trekking.md
+++ b/minigames/temple-trekking.md
@@ -35,8 +35,8 @@ You can do temple trekking by using `/minigames temple_trek start` and then choo
 ### **Ivandis/Blisterwood Flail**
 
 * `/craft`` `**`name:`**`Silver sickle`
-* `/create`` `**`item:`**`Ivandis Flail` - Requires Silver sickle + cut emerald
-* `/create`` `**`item:`**`Blisterwood Flail` - Requires Silver sickle + cut ruby
+* `/create`` `**`item:`**`Ivandis Flail` - Requires Silver sickle + cut emerald  (requires 75 QP and relevant quest skills)
+* `/create`` `**`item:`**`Blisterwood Flail` - Requires Ivandis Flail + cut ruby (requires 125 QP and relevant quest skills)
 
 ### Salve Amulet (e)
 


### PR DESCRIPTION
### Description:

Updating the flail boost section in Temple Trekking with correct info.

### Changes:

- Ivandis flail needs: https://github.com/oldschoolgg/oldschoolbot/blob/ad04bd73b17a8072035b1214e53343a839d2a521/src/lib/data/createables.ts#L1608
- Blisterwood flail needs Ivandis, and https://github.com/oldschoolgg/oldschoolbot/blob/ad04bd73b17a8072035b1214e53343a839d2a521/src/lib/data/createables.ts#L1620

### Confirm Changes
-  [x] I have tested all my changes thoroughly.
